### PR TITLE
Incrementally load ECCC radar images

### DIFF
--- a/Clouds/Application/Services/RadarService.swift
+++ b/Clouds/Application/Services/RadarService.swift
@@ -16,6 +16,7 @@ final class RadarService: ObservableObject {
 
     @Published var currentImageIndex: Int = 0
     @Published var isPlaying: Bool = false
+    @Published var shouldLazyLoadImages = false
 
     private let timer = RadarAnimationTimer()
 
@@ -57,6 +58,7 @@ final class RadarService: ObservableObject {
     func getRadarTimestamps(for provider: RadarProvider) {
         let query = RadarTimestampsQuery(provider: provider)
         loading = true
+        shouldLazyLoadImages = provider == .environmentCanada
 
         apolloCancellable = GraphQL.shared.apollo.fetch(query: query, cachePolicy: .fetchIgnoringCacheCompletely) { result in
             switch result {

--- a/Clouds/Sections/Radar/Components/RadarMap/RadarMapViewContainer.swift
+++ b/Clouds/Sections/Radar/Components/RadarMap/RadarMapViewContainer.swift
@@ -16,6 +16,7 @@ struct RadarMapViewContainer: Container {
 
     @Binding var currentImage: Int
     var dates: [Date]
+    var shouldLazyLoadImages: Bool = false
 
     var body: some View {
         RadarMapView(
@@ -23,7 +24,8 @@ struct RadarMapViewContainer: Container {
             dates: dates,
             overlayOpacity: settingsSheetState.radarOpacity,
             dataSource: settingsSheetState.radarSource,
-            activeLocationCoordinates: activeLocationCoordinates
+            activeLocationCoordinates: activeLocationCoordinates,
+            lazy: shouldLazyLoadImages
         )
         .equatable()
         .clipShape(RoundedCornerShape(cornerRadius: Dimension.Global.cornerRadius, style: .continuous, corners: [.bottomLeft, .bottomRight]))

--- a/Clouds/Sections/Radar/RadarSection.swift
+++ b/Clouds/Sections/Radar/RadarSection.swift
@@ -15,7 +15,11 @@ struct RadarSection: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
-            RadarMapViewContainer(currentImage: $radarService.currentImageIndex, dates: radarService.dates)
+            RadarMapViewContainer(
+                currentImage: $radarService.currentImageIndex,
+                dates: radarService.dates,
+                shouldLazyLoadImages: radarService.shouldLazyLoadImages
+            )
 
             RadarControls(
                 loading: radarService.loading || radarService.dates.isEmpty,


### PR DESCRIPTION
### What is the problem being solved in this PR?
The ECCC GeoMet server is not able to handle tens of requests at once for radar tiles. This PR adds a new `lazy` option to the `RadarMapView` which allows the map to load radar images when they are first displayed, rather than all at once, but only when using the ECCC radar data source.

### Related issues or PRs
Resolves #38 

### Why did you choose this approach?
Users want their radar images to be displayed immediately. This change gives the illusion that radar images are loaded quickly, since the initial image is displayed immediately. If the user wants to see more, they can press play or scrub, and the images will load as needed.

While the experience of the first play may be jarring, it is much clearer as to what is happening. Rather than staring at a blank map for up to 20 seconds, the user sees that images are slowly starting to load.

### How to test changes
1. Go to the Radar section.
1. Ensure ECCC is selected as the data source.
1. Press play and ensure and observe that the images are loaded on every tick.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] If this changes any of the app's behaviour, I've made it easy for users to transition to the new behaviour.
- [x] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
