### PR TITLE
Upgrade Mapbox to 6.0.0

### DIFF
--- a/.github/workflows/xcode.yml
+++ b/.github/workflows/xcode.yml
@@ -20,6 +20,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v2
 
+      - name: Install Secrets
+        shell: bash
+        env:
+          MAPBOX_SDK_PACKAGE_TOKEN: ${{ secrets.MAPBOX_SDK_PACKAGE_TOKEN }}
+        run: echo -e "machine api.mapbox.com\n login mapbox\n password $MAPBOX_SDK_PACKAGE_TOKEN" > ~/.netrc
+
       - name: Cache Dependencies
         uses: actions/cache@v2
         id: carthage-cache
@@ -31,7 +37,7 @@ jobs:
 
       - name: Install Carthage Dependencies
         if: steps.carthage-cache.outputs.cache-hit != 'true'
-        run: carthage bootstrap --no-use-binaries --platform iOS --cache-builds
+        run: carthage bootstrap --no-use-binaries --platform iOS --cache-builds --use-netrc
 
       - name: Build App
         run: set -o pipefail && xcodebuild clean build -project Clouds.xcodeproj -scheme Clouds -configuration Debug CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO CODE_SIGNING_ALLOWED=NO | xcpretty --simple

--- a/Cartfile
+++ b/Cartfile
@@ -1,3 +1,3 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" ~> 5.9
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" ~> 6.0.0
 github "mapbox/mapbox-events-ios" ~> 0.10
 github "bugsnag/bugsnag-cocoa"

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,3 +1,3 @@
-binary "https://www.mapbox.com/ios-sdk/Mapbox-iOS-SDK.json" "5.9.0"
 github "bugsnag/bugsnag-cocoa" "v5.23.2"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.0.0"
 github "mapbox/mapbox-events-ios" "v0.10.2"

--- a/README.md
+++ b/README.md
@@ -71,10 +71,12 @@ Then, navigate into the cloned repository:
 cd clouds
 ```
 
-Clouds primarily uses Swift Package Manager to manage dependencies. However, some dependences (namely the [Mapbox SDK](https://docs.mapbox.com/ios/maps/overview/)) are installed using [Carthage](https://github.com/Carthage/Carthage). If you don't already have Carthage installed, you should install it before proceeding. Once Carthage is installed, run the following command to checkout and build the dependencies:
+If it's your first time contributing, you'll need to register for a Mapbox account and [create a new access token](https://docs.mapbox.com/ios/maps/overview/#configure-credentials) and add it to your `~/.netrc` file. The article linked describes how to create such a file and how to format it. This secret is automatically configured in GitHub Actions runs.
+
+Clouds primarily uses Swift Package Manager to manage dependencies. However, some dependences (namely the [Mapbox SDK](https://docs.mapbox.com/ios/maps/overview/)) are installed using [Carthage](https://github.com/Carthage/Carthage). If you don't already have Carthage installed, you should install it before proceeding. Once Carthage is installed, run the following command to install the dependencies. Make sure you include the `--use-netrc` option to use the credentials you configured earlier.
 
 ```sh
-carthage update --platform ios
+carthage bootstrap --platform ios --use-netrc
 ```
 
 You can then open the Xcode project (named `Clouds.xcodeproj`) in Xcode.


### PR DESCRIPTION
### What is the problem being solved in this PR?
This PR upgrades the Mapbox SDK to `6.0.0`. As of `6.0.0`, the Mapbox SDK is downloaded as a binary-only library (see https://github.com/mapbox/mapbox-gl-native-ios/releases/tag/ios-v6.0.0).  As a result, we must now set up a `~/.netrc` file with the correct credentials to download the package. The instructions have been updated in the README.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
