### PR TITLE
Add Analytics via Microsoft App Center

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,3 +92,4 @@ Carthage/
 **/fastlane/screenshots/*.html
 
 **/fastlane/test_output
+Clouds/Secrets.plist

--- a/Cartfile
+++ b/Cartfile
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" ~> 6.2.0
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" ~> 6.2.1
 github "mapbox/mapbox-events-ios" ~> 0.10.4

--- a/Cartfile.resolved
+++ b/Cartfile.resolved
@@ -1,2 +1,2 @@
-binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.2.0"
-github "mapbox/mapbox-events-ios" "v0.10.4"
+binary "https://api.mapbox.com/downloads/v2/carthage/mobile-maps/mapbox-ios-sdk-dynamic.json" "6.2.1"
+github "mapbox/mapbox-events-ios" "v0.10.5"

--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -49,6 +49,8 @@
 		802A4303241C54AB0073C0DC /* DismissableScrollViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802A4302241C54AB0073C0DC /* DismissableScrollViewRepresentable.swift */; };
 		802A4305241C556A0073C0DC /* DismissableScrollViewHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802A4304241C556A0073C0DC /* DismissableScrollViewHostingController.swift */; };
 		802C082B253B3D5700913021 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 802C082A253B3D5700913021 /* AppCenterAnalytics */; };
+		802C089D253B64A200913021 /* Secrets.plist in Resources */ = {isa = PBXBuildFile; fileRef = 802C089C253B64A200913021 /* Secrets.plist */; };
+		802C08A6253B65CE00913021 /* SecretsSample.plist in Resources */ = {isa = PBXBuildFile; fileRef = 802C08A5253B65CE00913021 /* SecretsSample.plist */; };
 		802C0D982368FE32009A22BA /* CurrentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C0D972368FE32009A22BA /* CurrentSection.swift */; };
 		802C0D9C236903C6009A22BA /* SunriseSunsetTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C0D9B236903C6009A22BA /* SunriseSunsetTime.swift */; };
 		802C0D9E236903CD009A22BA /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C0D9D236903CD009A22BA /* Header.swift */; };
@@ -301,6 +303,8 @@
 		802A42FE241C534F0073C0DC /* DismissableScrollViewModifier.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableScrollViewModifier.swift; sourceTree = "<group>"; };
 		802A4302241C54AB0073C0DC /* DismissableScrollViewRepresentable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableScrollViewRepresentable.swift; sourceTree = "<group>"; };
 		802A4304241C556A0073C0DC /* DismissableScrollViewHostingController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DismissableScrollViewHostingController.swift; sourceTree = "<group>"; };
+		802C089C253B64A200913021 /* Secrets.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Secrets.plist; sourceTree = "<group>"; };
+		802C08A5253B65CE00913021 /* SecretsSample.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; path = SecretsSample.plist; sourceTree = "<group>"; };
 		802C0D972368FE32009A22BA /* CurrentSection.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CurrentSection.swift; sourceTree = "<group>"; };
 		802C0D9B236903C6009A22BA /* SunriseSunsetTime.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SunriseSunsetTime.swift; sourceTree = "<group>"; };
 		802C0D9D236903CD009A22BA /* Header.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Header.swift; sourceTree = "<group>"; };
@@ -876,6 +880,8 @@
 				805D7BDB22D1244800A12C4D /* Images.xcassets */,
 				805A175022C53ADD00E1B4E2 /* LaunchScreen.storyboard */,
 				805A175322C53ADD00E1B4E2 /* Info.plist */,
+				802C089C253B64A200913021 /* Secrets.plist */,
+				802C08A5253B65CE00913021 /* SecretsSample.plist */,
 				805A174D22C53ADD00E1B4E2 /* Preview Content */,
 			);
 			path = Clouds;
@@ -1654,6 +1660,7 @@
 			isa = PBXNativeTarget;
 			buildConfigurationList = 805A175622C53ADD00E1B4E2 /* Build configuration list for PBXNativeTarget "Clouds" */;
 			buildPhases = (
+				802C08A4253B657300913021 /* Create Secrets Property List */,
 				80273A79251598BD00E02891 /* SwiftLint */,
 				805A173E22C53ADB00E1B4E2 /* Sources */,
 				805A173F22C53ADB00E1B4E2 /* Frameworks */,
@@ -1703,7 +1710,7 @@
 		805A173A22C53ADB00E1B4E2 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastSwiftUpdateCheck = 1150;
+				LastSwiftUpdateCheck = 1200;
 				LastUpgradeCheck = 1200;
 				ORGANIZATIONNAME = "Lukas Romsicki";
 				TargetAttributes = {
@@ -1772,12 +1779,14 @@
 			isa = PBXResourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				802C08A6253B65CE00913021 /* SecretsSample.plist in Resources */,
 				8021717E245517FE00D6C958 /* WeatherLocationItem.graphql in Resources */,
 				80F07DDC23FB7D0C005C43A3 /* schema.json in Resources */,
 				80042F1724284C2A005DA891 /* LaunchScreen.storyboard in Resources */,
 				805D7BDC22D1244800A12C4D /* Images.xcassets in Resources */,
 				805D7BDA22D1243F00A12C4D /* Colors.xcassets in Resources */,
 				805A174F22C53ADD00E1B4E2 /* Preview Assets.xcassets in Resources */,
+				802C089D253B64A200913021 /* Secrets.plist in Resources */,
 				8083A824244A579C00CE2E5E /* RadarTimestamps.graphql in Resources */,
 				809833B922F678BE001C1590 /* Weather.graphql in Resources */,
 				805A174C22C53ADD00E1B4E2 /* Assets.xcassets in Resources */,
@@ -1831,6 +1840,24 @@
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;
 			shellScript = "if which mint >/dev/null; then\n  mint run swiftlint\nelse\n  echo \"warning: Mint not installed.\"\nfi\n";
+		};
+		802C08A4253B657300913021 /* Create Secrets Property List */ = {
+			isa = PBXShellScriptBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+			);
+			inputFileListPaths = (
+			);
+			inputPaths = (
+			);
+			name = "Create Secrets Property List";
+			outputFileListPaths = (
+			);
+			outputPaths = (
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+			shellPath = /bin/sh;
+			shellScript = "CONFIG_FILE_BASE_NAME=\"Secrets\"\n\nCONFIG_FILE_NAME=${CONFIG_FILE_BASE_NAME}.plist\nSAMPLE_CONFIG_FILE_NAME=${CONFIG_FILE_BASE_NAME}Sample.plist\n\nCONFIG_FILE_PATH=$SRCROOT/$PRODUCT_NAME/$CONFIG_FILE_NAME\nSAMPLE_CONFIG_FILE_PATH=$SRCROOT/$PRODUCT_NAME/$SAMPLE_CONFIG_FILE_NAME\n\nif [ -f \"$CONFIG_FILE_PATH\" ]; then\n  echo \"$CONFIG_FILE_PATH exists.\"\nelse\n  echo \"$CONFIG_FILE_PATH does not exist, copying sample\"\n  cp -v \"${SAMPLE_CONFIG_FILE_PATH}\" \"${CONFIG_FILE_PATH}\"\nfi\n";
 		};
 		8083A813244949DF00CE2E5E /* Copy Carthage Frameworks */ = {
 			isa = PBXShellScriptBuildPhase;

--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 52;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -1843,6 +1843,7 @@
 		};
 		802C08A4253B657300913021 /* Create Secrets Property List */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
@@ -1854,6 +1855,7 @@
 			outputFileListPaths = (
 			);
 			outputPaths = (
+				"$(SRCROOT)/$(PRODUCT_NAME)/Secrets.plist",
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 			shellPath = /bin/sh;

--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -48,6 +48,7 @@
 		802A42FF241C534F0073C0DC /* DismissableScrollViewModifier.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802A42FE241C534F0073C0DC /* DismissableScrollViewModifier.swift */; };
 		802A4303241C54AB0073C0DC /* DismissableScrollViewRepresentable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802A4302241C54AB0073C0DC /* DismissableScrollViewRepresentable.swift */; };
 		802A4305241C556A0073C0DC /* DismissableScrollViewHostingController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802A4304241C556A0073C0DC /* DismissableScrollViewHostingController.swift */; };
+		802C082B253B3D5700913021 /* AppCenterAnalytics in Frameworks */ = {isa = PBXBuildFile; productRef = 802C082A253B3D5700913021 /* AppCenterAnalytics */; };
 		802C0D982368FE32009A22BA /* CurrentSection.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C0D972368FE32009A22BA /* CurrentSection.swift */; };
 		802C0D9C236903C6009A22BA /* SunriseSunsetTime.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C0D9B236903C6009A22BA /* SunriseSunsetTime.swift */; };
 		802C0D9E236903CD009A22BA /* Header.swift in Sources */ = {isa = PBXBuildFile; fileRef = 802C0D9D236903CD009A22BA /* Header.swift */; };
@@ -501,6 +502,7 @@
 			files = (
 				8083A81C24494AFB00CE2E5E /* MapboxMobileEvents.framework in Frameworks */,
 				80273A33251592AF00E02891 /* CloudsAPI.framework in Frameworks */,
+				802C082B253B3D5700913021 /* AppCenterAnalytics in Frameworks */,
 				80273AA32515A13400E02891 /* Bugsnag in Frameworks */,
 				80D0CE81235B6D95002A3EFD /* SwiftDate in Frameworks */,
 				8083A81A24494AFB00CE2E5E /* Mapbox.framework in Frameworks */,
@@ -1668,6 +1670,7 @@
 			packageProductDependencies = (
 				80D0CE80235B6D95002A3EFD /* SwiftDate */,
 				80273AA22515A13400E02891 /* Bugsnag */,
+				802C082A253B3D5700913021 /* AppCenterAnalytics */,
 			);
 			productName = Forecast;
 			productReference = 805A174222C53ADB00E1B4E2 /* Clouds.app */;
@@ -1735,6 +1738,7 @@
 				80D0CE82235B6DA5002A3EFD /* XCRemoteSwiftPackageReference "apollo-ios" */,
 				80F4481E245B60FF007AC77B /* XCRemoteSwiftPackageReference "swifter" */,
 				8016D2F024EC687200FD4A5F /* XCRemoteSwiftPackageReference "bugsnag-cocoa" */,
+				802C0829253B3D5700913021 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */,
 			);
 			productRefGroup = 805A174322C53ADB00E1B4E2 /* Products */;
 			projectDirPath = "";
@@ -2477,7 +2481,15 @@
 			repositoryURL = "https://github.com/bugsnag/bugsnag-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 6.1.4;
+				version = 6.2.1;
+			};
+		};
+		802C0829253B3D5700913021 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/microsoft/appcenter-sdk-apple";
+			requirement = {
+				kind = exactVersion;
+				version = 3.3.4;
 			};
 		};
 		80D0CE7F235B6D95002A3EFD /* XCRemoteSwiftPackageReference "SwiftDate" */ = {
@@ -2493,7 +2505,7 @@
 			repositoryURL = "https://github.com/apollographql/apollo-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 0.33.0;
+				version = 0.35.0;
 			};
 		};
 		80F4481E245B60FF007AC77B /* XCRemoteSwiftPackageReference "swifter" */ = {
@@ -2521,6 +2533,11 @@
 			isa = XCSwiftPackageProductDependency;
 			package = 8016D2F024EC687200FD4A5F /* XCRemoteSwiftPackageReference "bugsnag-cocoa" */;
 			productName = Bugsnag;
+		};
+		802C082A253B3D5700913021 /* AppCenterAnalytics */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 802C0829253B3D5700913021 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */;
+			productName = AppCenterAnalytics;
 		};
 		80D0CE80235B6D95002A3EFD /* SwiftDate */ = {
 			isa = XCSwiftPackageProductDependency;

--- a/Clouds/Application/Environment/AppEnvironment.swift
+++ b/Clouds/Application/Environment/AppEnvironment.swift
@@ -9,7 +9,19 @@
 import Foundation
 
 final class AppEnvironment {
+    private static var secrets: NSDictionary? {
+        guard let filePath = Bundle.main.path(forResource: "Secrets", ofType: "plist") else {
+            return NSDictionary()
+        }
+
+        return NSDictionary(contentsOfFile: filePath)
+    }
+
     static var isUITesting: Bool {
         ProcessInfo.processInfo.arguments.contains("UI_TESTING")
+    }
+
+    static var appCenterApiKey: String? {
+        secrets?.object(forKey: "AppCenterKey") as? String
     }
 }

--- a/Clouds/SecretsSample.plist
+++ b/Clouds/SecretsSample.plist
@@ -1,0 +1,12 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<!--
+   SecretsSample.plist
+   Clouds
+
+   Created by Lukas Romsicki on 2020-10-17.
+   Copyright (c) 2020 Lukas Romsicki. All rights reserved.
+-->
+<plist version="1.0">
+<dict/>
+</plist>


### PR DESCRIPTION
### What is the problem being solved in this PR?
This PR adds some basic analytics using Microsoft App Center Analytics so that I can roughly see which features users are actually using.

### Related issues or PRs
N/A

### Why did you choose this approach?
Microsoft App Center is simple and easy to use, and its SDK requires pretty minimal code changes.

I've added a new `Secrets.plist` (not checked into Git) that stores the App Center API key.  I've also create a `SecretsSample.plist` which is copied as `Secrets.plist` (which will be blank).

### How to test changes
Not possible.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
