### PR TITLE
Fix crash when adjusting settings

### DIFF
--- a/Clouds/Views/Master/MasterViewContainer.swift
+++ b/Clouds/Views/Master/MasterViewContainer.swift
@@ -18,9 +18,9 @@ struct MasterViewContainer: Container {
         }
         .equatable()
         .sheet(isPresented: $settingsSheetState.presented) {
-            // Using AnyView solves issues with missing EnvironmentObjects
-            AnyView(SettingsSection())
+            SettingsSection()
                 .preferredColorScheme(.dark)
+                .environmentObject(settingsSheetState)
         }
     }
 }


### PR DESCRIPTION
### What is the problem being solved in this PR?
Currently, adjusting some settings in the Settings screen causes the app to crash.

### Related issues or PRs
Resolves #55

### Why did you choose this approach?
- Wrapping the `SettingsSection` view in `AnyView` used to solve missing EnvironmentObject issues in early versions of iOS 14.  However, it appears that this issue was solved as of iOS 14.1.  Therefore, this workaround can be removed.

### How to test changes
1. Launch the app.
1. Open settings.
1. Drag the radar opacity slider.
1. Pull the sheet down slightly, but then pull it back up to a fully-open state.
1. Drag the radar opacity slider.
1. The app should not have crashed during any of these steps.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] If this changes any of the app's behaviour, I've made it easy for users to transition to the new behaviour.
- [x] I have added test cases, if needed.
- [ ] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
