### PR TITLE
Fix radar map overlay rendering and bump package versions

### DIFF
--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -2526,7 +2526,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_ASSET_PATHS = "Clouds/Preview\\ Content";
 				DEVELOPMENT_TEAM = 8P8574Z65P;
 				ENABLE_PREVIEWS = YES;
@@ -2540,7 +2540,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.romsicki.clouds;
 				PRODUCT_NAME = Clouds;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2557,7 +2557,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_ASSET_PATHS = "Clouds/Preview\\ Content";
 				DEVELOPMENT_TEAM = 8P8574Z65P;
 				ENABLE_PREVIEWS = YES;
@@ -2571,7 +2571,7 @@
 					"$(inherited)",
 					"@executable_path/Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.romsicki.clouds;
 				PRODUCT_NAME = Clouds;
 				PROVISIONING_PROFILE_SPECIFIER = "";
@@ -2588,7 +2588,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 8P8574Z65P;
 				INFOPLIST_FILE = CloudsWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -2597,7 +2597,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.romsicki.clouds.CloudsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
@@ -2613,7 +2613,7 @@
 				ASSETCATALOG_COMPILER_WIDGET_BACKGROUND_COLOR_NAME = WidgetBackground;
 				CODE_SIGN_IDENTITY = "Apple Development";
 				CODE_SIGN_STYLE = Automatic;
-				CURRENT_PROJECT_VERSION = 39;
+				CURRENT_PROJECT_VERSION = 40;
 				DEVELOPMENT_TEAM = 8P8574Z65P;
 				INFOPLIST_FILE = CloudsWidget/Info.plist;
 				IPHONEOS_DEPLOYMENT_TARGET = 14.0;
@@ -2622,7 +2622,7 @@
 					"@executable_path/Frameworks",
 					"@executable_path/../../Frameworks",
 				);
-				MARKETING_VERSION = 1.3.2;
+				MARKETING_VERSION = 1.4.0;
 				PRODUCT_BUNDLE_IDENTIFIER = com.romsicki.clouds.CloudsWidget;
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;

--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -2736,7 +2736,7 @@
 			repositoryURL = "https://github.com/bugsnag/bugsnag-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 6.2.5;
+				version = 6.8.3;
 			};
 		};
 		802C0829253B3D5700913021 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */ = {
@@ -2744,7 +2744,7 @@
 			repositoryURL = "https://github.com/microsoft/appcenter-sdk-apple";
 			requirement = {
 				kind = exactVersion;
-				version = 4.0.0;
+				version = 4.1.1;
 			};
 		};
 		80D0CE7F235B6D95002A3EFD /* XCRemoteSwiftPackageReference "SwiftDate" */ = {
@@ -2760,7 +2760,7 @@
 			repositoryURL = "https://github.com/apollographql/apollo-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 0.37.0;
+				version = 0.42.0;
 			};
 		};
 		80F4481E245B60FF007AC77B /* XCRemoteSwiftPackageReference "swifter" */ = {

--- a/Clouds/Sections/Radar/Components/RadarMap/RadarMapView.swift
+++ b/Clouds/Sections/Radar/Components/RadarMap/RadarMapView.swift
@@ -31,7 +31,7 @@ struct RadarMapView: UIViewRepresentable {
         }
 
         mapView.contentInset = UIEdgeInsets(
-            top: Dimension.Header.omniBarHeight + (2 * Dimension.Global.padding),
+            top: Dimension.Header.omniBarHeight + Dimension.System.topSafeMargin + (2 * Dimension.Global.padding),
             left: 8,
             bottom: 8,
             right: 8

--- a/CloudsWidget/Views/CloudsWidgetEntryView.swift
+++ b/CloudsWidget/Views/CloudsWidgetEntryView.swift
@@ -28,6 +28,11 @@ struct CloudsWidgetEntryView: View {
                     Text("\(temperature!)°")
                         .font(.largeTitle)
                         .fontWeight(.heavy)
+                } else {
+                    Text("––")
+                        .font(.largeTitle)
+                        .fontWeight(.semibold)
+                        .opacity(0.5)
                 }
 
                 Text(entry.description ?? "No weather data")


### PR DESCRIPTION
### What is the problem being solved in this PR?
This PR fixes a few issues:
- Issue where map scale and compass would render underneath the search bar.
- Widget displays blank when there is no temperature observed (replaced with `––` empty state).

It also bumps all dependencies and bumps the app version to `1.4.0`.

### Related issues or PRs
N/A

### Why did you choose this approach?
Regular maintenance and bug fixes.

### How to test changes
1. Launch the app.
2. Go to the Radar page, ensure that the scale is below the top bar.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] If this changes any of the app's behaviour, I've made it easy for users to transition to the new behaviour.
- [x] I have added test cases, if needed.
- [x] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
