### PR TITLE
Display tendency next to pressure

### DIFF
--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -2736,7 +2736,7 @@
 			repositoryURL = "https://github.com/bugsnag/bugsnag-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 6.8.3;
+				version = 6.10.2;
 			};
 		};
 		802C0829253B3D5700913021 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */ = {
@@ -2744,7 +2744,7 @@
 			repositoryURL = "https://github.com/microsoft/appcenter-sdk-apple";
 			requirement = {
 				kind = exactVersion;
-				version = 4.1.1;
+				version = 4.2.0;
 			};
 		};
 		80D0CE7F235B6D95002A3EFD /* XCRemoteSwiftPackageReference "SwiftDate" */ = {
@@ -2760,7 +2760,7 @@
 			repositoryURL = "https://github.com/apollographql/apollo-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 0.42.0;
+				version = 0.45.0;
 			};
 		};
 		80F4481E245B60FF007AC77B /* XCRemoteSwiftPackageReference "swifter" */ = {

--- a/Clouds/Sections/Now/Components/MeasurementGrid/MeasurementGridContainer.swift
+++ b/Clouds/Sections/Now/Components/MeasurementGrid/MeasurementGridContainer.swift
@@ -6,6 +6,7 @@
 //  Copyright © 2020 Lukas Romsicki. All rights reserved.
 //
 
+import CloudsAPI
 import SwiftUI
 
 struct MeasurementGridContainer: Container {
@@ -25,7 +26,7 @@ struct MeasurementGridContainer: Container {
     }
 
     private func didCalculateHeight(height: CGFloat) {
-        self.appState.detailsContentHeight = height
+        appState.detailsContentHeight = height
     }
 
     private var measurements: [MeasurementDescriptor] {
@@ -49,10 +50,12 @@ struct MeasurementGridContainer: Container {
 
         // MARK: - Atmospheric Pressure 📈
 
-        if let pressure = currentConditions.pressure.value {
+        if let pressure = currentConditions.pressure.value, let tendency = currentConditions.pressure.tendency {
+            let tendencyArrow = arrow(for: tendency)
+
             let item = MeasurementDescriptor(
                 label: "Pressure",
-                value: "\(pressure) kPa",
+                value: "\(pressure) kPa\(tendencyArrow)",
                 color: .green
             )
 
@@ -122,6 +125,17 @@ struct MeasurementGridContainer: Container {
         }
 
         return observations
+    }
+
+    private func arrow(for tendency: CloudsAPI.Tendency) -> String {
+        switch tendency {
+        case .rising:
+            return " ↑"
+        case .falling:
+            return " ↓"
+        default:
+            return ""
+        }
     }
 }
 

--- a/Clouds/Sections/Week/Components/DayPickerPaging/DayPickerPagingViewContainer.swift
+++ b/Clouds/Sections/Week/Components/DayPickerPaging/DayPickerPagingViewContainer.swift
@@ -44,8 +44,7 @@ struct DayPickerPagingViewContainer: Container {
         }
 
         return days.compactMap { day in
-            let date = Date(seconds: Double(day.time), region: .UTC)
-                .convertTo(region: .current).date
+            let date = Date(seconds: Double(day.time), region: .UTC).date
 
             return DayPickerPagingView.Item(day: date.weekdayName(.short), date: date.day)
         }

--- a/CloudsAPI/GraphQL/Weather.graphql
+++ b/CloudsAPI/GraphQL/Weather.graphql
@@ -30,6 +30,7 @@ query Weather($latitude: Float!, $longitude: Float!) {
             humidity
             pressure {
                 value
+                tendency
             }
             feelsLike {
                 temperature

--- a/CloudsAPI/Sources/Generated/API.swift
+++ b/CloudsAPI/Sources/Generated/API.swift
@@ -281,6 +281,51 @@ public enum CloudsAPI {
     }
   }
 
+  public enum Tendency: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
+    public typealias RawValue = String
+    case rising
+    case falling
+    case stable
+    /// Auto generated constant for unknown enum values
+    case __unknown(RawValue)
+
+    public init?(rawValue: RawValue) {
+      switch rawValue {
+        case "rising": self = .rising
+        case "falling": self = .falling
+        case "stable": self = .stable
+        default: self = .__unknown(rawValue)
+      }
+    }
+
+    public var rawValue: RawValue {
+      switch self {
+        case .rising: return "rising"
+        case .falling: return "falling"
+        case .stable: return "stable"
+        case .__unknown(let value): return value
+      }
+    }
+
+    public static func == (lhs: Tendency, rhs: Tendency) -> Bool {
+      switch (lhs, rhs) {
+        case (.rising, .rising): return true
+        case (.falling, .falling): return true
+        case (.stable, .stable): return true
+        case (.__unknown(let lhsValue), .__unknown(let rhsValue)): return lhsValue == rhsValue
+        default: return false
+      }
+    }
+
+    public static var allCases: [Tendency] {
+      return [
+        .rising,
+        .falling,
+        .stable,
+      ]
+    }
+  }
+
   public enum FeelsLikeType: RawRepresentable, Equatable, Hashable, CaseIterable, Apollo.JSONDecodable, Apollo.JSONEncodable {
     public typealias RawValue = String
     case humidex
@@ -417,6 +462,7 @@ public enum CloudsAPI {
             pressure {
               __typename
               value
+              tendency
             }
             feelsLike {
               __typename
@@ -1044,6 +1090,7 @@ public enum CloudsAPI {
               return [
                 GraphQLField("__typename", type: .nonNull(.scalar(String.self))),
                 GraphQLField("value", type: .scalar(Double.self)),
+                GraphQLField("tendency", type: .scalar(Tendency.self)),
               ]
             }
 
@@ -1053,8 +1100,8 @@ public enum CloudsAPI {
               self.resultMap = unsafeResultMap
             }
 
-            public init(value: Double? = nil) {
-              self.init(unsafeResultMap: ["__typename": "Pressure", "value": value])
+            public init(value: Double? = nil, tendency: Tendency? = nil) {
+              self.init(unsafeResultMap: ["__typename": "Pressure", "value": value, "tendency": tendency])
             }
 
             public var __typename: String {
@@ -1072,6 +1119,15 @@ public enum CloudsAPI {
               }
               set {
                 resultMap.updateValue(newValue, forKey: "value")
+              }
+            }
+
+            public var tendency: Tendency? {
+              get {
+                return resultMap["tendency"] as? Tendency
+              }
+              set {
+                resultMap.updateValue(newValue, forKey: "tendency")
               }
             }
           }


### PR DESCRIPTION
### What is the problem being solved in this PR?
This PR adds an arrow next to the current pressure which represents the tendency (trend) of the pressure at the time of observation.  It also fixes an issue that caused the days on the Week screen to be incorrectly converted to a different timezone.

### Related issues or PRs
N/A

### Why did you choose this approach?
N/A

### How to test changes
1. Launch the app.
2. View the pressure. Observe that an arrow is displayed.
3. View the Week page. Observe that the days are accurate.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] If this changes any of the app's behaviour, I've made it easy for users to transition to the new behaviour.
- [x] I have added test cases, if needed.
- [ ] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
