### PR TITLE
Fix issue where data would not load on foreground enter

### DIFF
--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -2731,7 +2731,7 @@
 			repositoryURL = "https://github.com/apollographql/apollo-ios";
 			requirement = {
 				kind = exactVersion;
-				version = 0.49.1;
+				version = 0.50.0;
 			};
 		};
 		80F4481E245B60FF007AC77B /* XCRemoteSwiftPackageReference "swifter" */ = {

--- a/Clouds.xcodeproj/project.pbxproj
+++ b/Clouds.xcodeproj/project.pbxproj
@@ -2699,7 +2699,7 @@
 			repositoryURL = "https://github.com/bugsnag/bugsnag-cocoa";
 			requirement = {
 				kind = exactVersion;
-				version = 6.14.3;
+				version = 6.15.1;
 			};
 		};
 		802C0829253B3D5700913021 /* XCRemoteSwiftPackageReference "appcenter-sdk-apple" */ = {

--- a/Clouds/Application/CloudsApp.swift
+++ b/Clouds/Application/CloudsApp.swift
@@ -160,10 +160,7 @@ struct CloudsApp: App {
         }
 
         locationService.startUpdatingLocation()
-
-        if locationService.locationStatus != .authorizedWhenInUse || locationFavoritesService.activeLocation != nil {
-            fetchUpdatedWeatherData()
-        }
+        fetchUpdatedWeatherData()
     }
 
     private func applicationDidBecomeInactive() {
@@ -270,7 +267,6 @@ struct CloudsApp: App {
         }
 
         locationSearchService.searchQuery.clear()
-        fetchUpdatedWeatherData()
     }
 
     // MARK: - Radar

--- a/Clouds/Application/Services/LocationService.swift
+++ b/Clouds/Application/Services/LocationService.swift
@@ -42,6 +42,14 @@ extension LocationService: CLLocationManagerDelegate {
 
     func locationManager(_ manager: CLLocationManager, didUpdateLocations locations: [CLLocation]) {
         guard let location = locations.last else { return }
+
+        guard
+            location.coordinate.latitude != self.lastLocation?.coordinate.latitude ||
+            location.coordinate.longitude != self.lastLocation?.coordinate.longitude
+        else {
+            return
+        }
+
         self.lastLocation = location
 
         self.getPlace(for: location) { placemark in

--- a/Clouds/Sections/Location/Components/LocationPicker/Components/FavoriteLocationsGroup/FavoriteLocationsGroupContainer.swift
+++ b/Clouds/Sections/Location/Components/LocationPicker/Components/FavoriteLocationsGroup/FavoriteLocationsGroupContainer.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 struct FavoriteLocationsGroupContainer: Container {
     @EnvironmentObject private var locationPickerState: LocationPickerState
-    @EnvironmentObject private var weatherService: WeatherService
     @EnvironmentObject private var locationFavoritesService: LocationFavoritesService
 
     var body: some View {

--- a/Clouds/Sections/Location/Components/LocationPicker/Components/SearchResultsGroup/SearchResultsGroupContainer.swift
+++ b/Clouds/Sections/Location/Components/LocationPicker/Components/SearchResultsGroup/SearchResultsGroupContainer.swift
@@ -12,7 +12,6 @@ struct SearchResultsGroupContainer: Container {
     @EnvironmentObject private var locationSearchService: LocationSearchService
     @EnvironmentObject private var locationFavoritesService: LocationFavoritesService
     @EnvironmentObject private var locationPickerState: LocationPickerState
-    @EnvironmentObject private var weatherService: WeatherService
 
     var body: some View {
         SearchResultsGroup(

--- a/Clouds/Views/Master/Components/MasterViewLayout/Components/WeatherIllustration.swift
+++ b/Clouds/Views/Master/Components/MasterViewLayout/Components/WeatherIllustration.swift
@@ -18,13 +18,13 @@ struct WeatherIllustration: View {
     var body: some View {
         ZStack(alignment: .topTrailing) {
             if imageA != nil {
-                WeatherIllustrationImage(image: imageA!, shouldScale: shouldScaleImage)
+                WeatherIllustrationImage(image: imageA!, useSmallSize: shouldUseSmallSize)
                     .equatable()
                     .transition(transition)
             }
 
             if imageB != nil {
-                WeatherIllustrationImage(image: imageB!, shouldScale: shouldScaleImage)
+                WeatherIllustrationImage(image: imageB!, useSmallSize: shouldUseSmallSize)
                     .equatable()
                     .transition(transition)
             }
@@ -53,8 +53,8 @@ struct WeatherIllustration: View {
         alternateImage.toggle()
     }
 
-    private var shouldScaleImage: Bool {
-        ![.fog, .snow].contains(visualState.appearance.style)
+    private var shouldUseSmallSize: Bool {
+        Dimension.System.deviceIsiPhone8 && ![.fog, .snow].contains(visualState.appearance.style)
     }
 }
 

--- a/Clouds/Views/Master/Components/MasterViewLayout/Components/WeatherIllustrationImage.swift
+++ b/Clouds/Views/Master/Components/MasterViewLayout/Components/WeatherIllustrationImage.swift
@@ -10,19 +10,21 @@ import SwiftUI
 
 struct WeatherIllustrationImage: View {
     var image: Image
-    var shouldScale: Bool
+    var useSmallSize: Bool
 
     var body: some View {
         Group {
-            if Dimension.System.deviceIsiPhone8 && shouldScale {
+            if useSmallSize {
                 image
                     .resizable()
                     .aspectRatio(contentMode: .fit)
                     .frame(maxWidth: 300)
                     .offset(y: Dimension.Global.padding)
-
             } else {
                 image
+                    .resizable()
+                    .aspectRatio(contentMode: .fit)
+                    .offset(y: Dimension.Global.padding)
             }
         }
     }
@@ -32,6 +34,6 @@ extension WeatherIllustrationImage: Equatable {}
 
 struct WeatherIllustrationImage_Previews: PreviewProvider {
     static var previews: some View {
-        WeatherIllustrationImage(image: Image(""), shouldScale: true)
+        WeatherIllustrationImage(image: Image(""), useSmallSize: true)
     }
 }


### PR DESCRIPTION
### What is the problem being solved in this PR?
This PR fixes an issue where the weather data did not load after the app returned to the foreground. This PR also:
- Bumps some dependency versions.
- Fixes illustration scaling on screen sizes larger than the iPhone 11 screen size.

### Related issues or PRs
Resolves #68

### Why did you choose this approach?
Previously, we were relying on a location update on launch (as CoreLocation initialized) to trigger a weather data refresh. However, the last known location now appears to persist in recent iOS versions so the value does not actually change, and so it does not trigger a data load. With this change, data is now always loaded when the app enters foreground. Subsequent changes to location will trigger additional refreshes as needed.

### How to test changes
1. Launch the app.
2. Move it to the background.
3. Move it to the foreground.
4. Observe that new data loaded.

### Checklist
- [x] I've added the appropriate status labels to this PR, and I've self-assigned it.
- [x] I have tested my own changes locally.
- [x] If this changes any of the app's behaviour, I've made it easy for users to transition to the new behaviour.
- [x] I have added test cases, if needed.
- [ ] It is safe to revert these changes. That is, reverting this particular PR won't break anything.
